### PR TITLE
Fixes https://github.com/pariola/paystack/issues/1 for verification.resolveAccount endpoint

### DIFF
--- a/resources/verification.js
+++ b/resources/verification.js
@@ -28,7 +28,7 @@ module.exports = {
   resolveAccount: {
     method: "get",
     route: `${route}/resolve`,
-    params: ["account_number", "bank_code"]
+    args: ["account_number", "bank_code"]
   },
 
   /*


### PR DESCRIPTION
QueryString parameters are expected to be defined via `args`, however, for `verification.resolveAccount` endpoint, they were defined via `params`, hence skipped altogether in the pre request configuration.

This commit fixes that solely for this endpoint at the moment, but similar updates would be required or other endpoints with this [issue](https://github.com/pariola/paystack/issues/1)