### PR TITLE
added getLink & sendLink methods to subscription resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ const paystack = new Paystack("secret_key");
   * enable
   * get
   * list
+  * getLink
+  * sendLink
 * transfer_control
   * balance
   * resendOTP

--- a/resources/subscription.js
+++ b/resources/subscription.js
@@ -47,5 +47,21 @@ module.exports = {
   get: {
     method: "get",
     route: `${route}/{id}`
+  },
+
+  /*
+  Generate Update Subscription Link
+  */
+  getLink: {
+    method: "get",
+    route: `${route}/{code}/manage/link`
+  },
+
+  /*
+  Send Update Subscription Link
+  */
+  sendLink: {
+    method: "post",
+    route: `${route}/{code}/manage/email`
   }
 };


### PR DESCRIPTION
These two methods are currently missing from the library.